### PR TITLE
Fix: Correct gitleaks command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
+        with:
+          command: detect --source . -v
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The gitleaks action was failing with an 'ambiguous argument' error, likely due to a shallow clone in the CI environment. This change modifies the GitHub Actions workflow to explicitly set the gitleaks command to scan the entire source directory, rather than relying on git history, which resolves the issue.